### PR TITLE
Update check-file-name.yml to run for PR instead of just `on push`

### DIFF
--- a/.github/workflows/check-file-name.yml
+++ b/.github/workflows/check-file-name.yml
@@ -1,6 +1,6 @@
 # This GitHub Action checks the folder for name mismatch 
 name: check file names
-on: [push]
+on: [pull_request]
 jobs:
   check_file_names:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 
Add some description
change - [ ]  to - [X] to mark it.
 -->
- [X] Action edit
 Fixed the bug where the github action runs, when a new PR is created not when on Push.

- [ ] Jira ticket number [#number](link)
- [ ] Created file results_`TicketNumber`_`ToolAbbreviation`in `/public/scan-results/data`

### Issues with some links 
- [ ] Skip some URL due an Error (List Included)
- [ ] Set Label `Missing_URL` for future reference


<!-- 
#### Additional Notes
-  -->
