### PR TITLE
Enhancement to Safari automation

### DIFF
--- a/public/tools/auto-audit/README.md
+++ b/public/tools/auto-audit/README.md
@@ -6,24 +6,25 @@ Auto-Audit is a python script I wrote to automate the repetitive part of the Cod
 
 ## Using:
 
-The basic invokation of the tool is with the last parameter set to the file path of the xlsx file. Eg:
+The basic invocation of the tool is with two positional parameters.  The first is the Jira ticket number and the second is the file path of the xlsx file. Eg:
 
 ```
-python auto-audit.py ~/Projects/Code4Good/RCB\ Home\ B2.xlsx
+python auto-audit.py C4G-99 ~/Projects/Code4Good/RCB\ Home\ B2.xlsx
 ```
 
 If you hit a snag and need to restart part way through you can add a `--start-at` parameter with the row number to start at. This number should be between 2 (skipping the headers) and the maximum row number.
 
 ```
-python auto-audit.py --start-at=24 ~/Projects/Code4Good/RCB\ Home\ B2.xlsx
+python auto-audit.py --start-at=24 C4G-99 ~/Projects/Code4Good/RCB\ Home\ B2.xlsx
 ```
 
 ## Scope:
 
-this is a simple python script that has 2 purposes:
+this is a simple python script that has 3 purposes:
 
 1. read each line of the input spreadsheet with openpyxl
 2. copy that url into the address bar of the browser and get that url with selenium
+3. move and rename the result file "~/Downloads/Accessibility Result.json" to your current directory using the file naming convention for this project (e.g. C4G-99_WK_2.json)
 
 ## Tools and Technologies:
 

--- a/public/tools/auto-audit/auto-audit.py
+++ b/public/tools/auto-audit/auto-audit.py
@@ -16,6 +16,7 @@ print("selenium version ==", selenium.__version__)
 
 parser = argparse.ArgumentParser(description='Automatically Process the URLs from a given XLSX file.')
 parser.add_argument('--start-at', type=int, default=2)
+parser.add_argument('jira_ticket')
 parser.add_argument('file_path')
 args = parser.parse_args()
 
@@ -30,6 +31,7 @@ for col in ascii_uppercase:
         max_col = col
 print(max_col)
 
+result_file = os.path.expanduser('~') + '/Downloads/Accessibility Result.json'
 start_row = max(args.start_at, 2)
 if start_row < sheet0.max_row:
     for i in range(start_row, sheet0.max_row + 1):
@@ -46,4 +48,11 @@ if start_row < sheet0.max_row:
 
         # pause the script to click around with mouse
         input()
+
+        #Rename the default file ~/Downloads/Accessibility Result.json
+        try:
+            os.rename(result_file,'{0}_WK_{1}.json'.format(args.jira_ticket, i))
+        except FileNotFoundError:
+            print("Error: Result file {0} not found.".format(result_file))
+
         driver.close()


### PR DESCRIPTION
Soliciting feedback on this change.  The idea is to save the manual step of selecting the file to save the json results.  Instead, the manual tester can accept the Safari default (~/Downloads/Accessibility Result.json) and the script will rename the file in the local directory based on our naming convention.  Requires the user supply the Jira ticket number on the command line.  If this change looks good, I'll update the README.md.
