### PR TITLE
Add autolh tool based on the lighthouse script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
+    "flags": "^0.1.3",
     "gh-pages": "^2.1.1",
+    "humanize-duration": "^3.22.0",
+    "node-fetch": "^2.6.0",
     "node-sass": "^4.13.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "^3.3.1",
     "react-tiny-popover": "^4.0.0",
-    "ua-parser-js": "^0.7.20"
+    "ua-parser-js": "^0.7.20",
+    "xml2js": "^0.4.23"
   },
   "scripts": {
     "predeploy": "npm run build",
@@ -21,6 +25,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "lighthouse": "node public/tools/auto-lighthouse/index.js",
+    "autolh": "node public/tools/auto-lighthouse/automated.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/public/tools/auto-lighthouse/automated.js
+++ b/public/tools/auto-lighthouse/automated.js
@@ -1,0 +1,162 @@
+// In the base folder (same level as package.json), run "npm run lighthouse".
+// Configure readWorkbook for the location of the excel sheet and
+// data file name prefix.
+
+const fs = require("fs");
+const lighthouse = require("lighthouse");
+const chromeLauncher = require("chrome-launcher");
+const flags = require("flags");
+const crypto = require("crypto");
+const path = require("path");
+const humanizeDuration = require("humanize-duration");
+
+flags.defineBoolean('linux', false, 'Run on linux. Disable Chrome sandbox.');
+flags.defineBoolean('headless', false, 'Use headless chrome.');
+flags.defineBoolean('reuse-chrome', true, 'Whether to reuse chrome instance for multiple audits.');
+flags.defineBoolean('clobber', false, 'If True, overwrite existing json reports.');
+
+flags.defineString('scan_id', 'data', 'Specifies top level directory to store audit results in.')
+flags.defineString('site', null, 'If specified, audit given site (rco, rcb) using sitemap.xls')
+flags.defineString('top-urls', null, 'Text file containing top urls.')
+// TODO: allow for passing custom url list
+
+// site can be rco, rcb and can automatically grab from sitemap
+
+// Output files into public/scan-results/${scan_id}/${site}.${kind}/${tool}/${md5sum}.json
+const RESULTS_FOLDER = "./public/scan-results";
+const SITEMAPS = {
+  rco: 'https://www.redcross.org/sitemap.xml',
+  rcb: 'https://www.redcrossblood.org/sitemap.xml'
+}
+
+const topUrls = (() => {
+  if (flags.get('top-urls')) {
+    return new Set(fs.readFileSync(filepath).toString().split("\n"));
+  } else {
+    return new Set();
+  }
+})();
+
+async function launchChrome() {
+  /// Launches chrome browser for the auditing.
+
+  var cflags = [];
+  if (flags.get('linux')) {
+    cflags.push('--no-sandbox');
+  }
+  if (flags.get('headless')) {
+    cflags.push('--headless');
+  }
+  return chromeLauncher.launch({chromeFlags: cflags})
+}
+
+async function getSitemap(site) {
+  /// Returns parsed sitemap object for a given website.
+
+  const url = SITEMAPS[site];
+  const https = require('https');
+  const xml2js = require('xml2js');
+  const fetch = require('node-fetch');
+
+  // Extracts urlset.url[].loc from the sitemap.xml
+  return fetch(url)
+    .then(res => res.text())
+    .then(txt => xml2js.parseStringPromise(txt))
+    .then(xml => xml.urlset.url.map(u => u.loc));
+}
+
+function auditFilename(site, url) {
+  /// Returns filename where audit report for this url should be written.
+
+  // "all" if no topUrls are given, "top"/"misc" otherwise.
+  let kind = topUrls.has(url) ? "top" : (topUrls.size ? "misc" : "all");
+  let md = crypto.createHash("md5").update(url.toString()).digest("hex");
+  return `${RESULTS_FOLDER}/${flags.get("scan_id")}/${site}.${kind}/lighthouse/${md}.json`
+}
+
+async function auditWebsite(site) {
+  /// Runs audit for a given website
+  const urlsToAudit = await getSitemap(site);
+  console.log(`Sitemap returned ${urlsToAudit.length} urls`);
+
+  let browser = null;
+  let badUrls = [];
+  if (flags.get('reuse-chrome')) {
+    browser = await launchChrome();
+  }
+
+  const startTime = Date.now();
+  for (let i=0; i < urlsToAudit.length; i++) {
+    const url = urlsToAudit[i];
+
+    const elapsed = (Date.now() - startTime);
+    if (i > 0) {
+      const perItem = (elapsed / i);
+      const timeLeft = perItem * (urlsToAudit.length - i);
+
+      const pctDone = Number.parseFloat(i*100/urlsToAudit.length).toFixed(1);
+      const elapsedStr = humanizeDuration(elapsed, {round: true, largest: 2});
+      const timeLeftStr = humanizeDuration(timeLeft, {round: true, largest: 2});
+      const perItemStr = humanizeDuration(perItem, {maxDecimalPoints: 1});
+
+      console.log(`[ ${i}/${urlsToAudit.length} (${pctDone}%) done ]`);
+      console.log(`[ ${elapsedStr} elapsed | ${timeLeftStr} left | ${perItemStr} per url ]`);
+    }
+
+    const auditFile = auditFilename(site, url);
+    if (fs.existsSync(auditFile) && !flags.get('clobber')) {
+      console.log(`Audit already exists for ${url}`);
+      continue;
+    }
+
+    console.log(`Starting audit of url ${url}`);
+    if (browser == null) {
+      browser = await launchChrome();
+    }
+
+    let results = null;
+    try {
+      results = await lighthouse(url, {
+        port: browser.port,
+        onlyCategories: ["performance", "accessibility"],
+        emulatedFormFactor: "desktop",
+      });
+    } catch(err) {
+      console.error(`Failed to audit ${url}: ${err}`);
+      badUrls.push(url);
+      continue;
+    }
+
+    if (results.report == undefined) {
+      console.error(`Failed to obtain report for url: {url}`)
+      badUrls.push(url);
+      continue;
+    }
+
+    const auditDir = path.dirname(auditFile);
+    if (!fs.existsSync(auditDir)) {
+      fs.mkdirSync(auditDir, {recursive: true});
+    }
+
+    fs.writeFile(auditFile, results.report, (err) => {
+      if (err) {
+        console.error(`Failed  to write report for url: ${url}`);
+        badUrls.push(url);
+      } else {
+        console.log(`Audit for ${url} written to ${auditFile}`);
+      }
+    });
+
+    if (!flags.get('reuse-chrome')) {
+      await browser.kill();
+      browser = null;
+    }
+  }
+  if (browser != null) {
+    browser.kill();
+  }
+  // Write bad urls somewhere
+} 
+
+flags.parse();
+auditWebsite(flags.get("site"));


### PR DESCRIPTION
This is a fork of `auto-lighthouse/index.js` that drops all legacy features and makes script intended for full automation available alongside.

This script will read `--sitemap {rco|rcb}` and generate audit files using [the new naming scheme](https://docs.google.com/document/d/1oKNztHfh11BrS8t8X2ZhiHxeYD-DFIQaNhP0-SH0w28/edit#).

There are few outstanding improvements we could focus on:
- print badUrls into json file somewhere alongside the audit files (maybe in `${scan_id}/${site}-lighthouse-bad-urls.json`)
- add flag that can supply custom set of urls when we don't want to read `sitemap.xml` (ideally a text file with one url per line)
- sort urls that are being scanned so that top urls are scanned first