### PR TITLE
Don't load the entire raw dataset in memory

### DIFF
--- a/public/tools/app-preprocessing/preprocess.js
+++ b/public/tools/app-preprocessing/preprocess.js
@@ -7,16 +7,6 @@ const path = require('path');
 const DATA_FOLDER = "./public/scan-results/data";
 const CHROME_REGEX = /C4G-[0-9]+_CD_[0-9]+.json/g;
 
-// TODO(winerip) do the filtering and aggregating in the loop to prevent storing the full data in memory.
-unfilteredJsonData = [];
-fs.readdirSync(DATA_FOLDER).forEach(file => {
-    if (file.match(CHROME_REGEX)) {
-        let json = JSON.parse(fs.readFileSync(path.join(DATA_FOLDER, file)));
-        json.url = '/scan-results/data/' + file;
-        if (json.requestedUrl) unfilteredJsonData.push(json);
-    }
-});
-
 let scores = {
     performance: 0,
     accessibility: 0,
@@ -31,12 +21,54 @@ let totals = {
     seo: 0,
     pwa: 0
 }
-for (let i = 0; i < unfilteredJsonData.length; i++) {
-    for (let key in unfilteredJsonData[i].categories) {
-        scores[key] += (unfilteredJsonData[i].categories[key].score * 100);
-        totals[key]++;
+let tracking = {};
+let filteredJsonData = []
+
+fs.readdirSync(DATA_FOLDER).forEach(file => {
+    if (file.match(CHROME_REGEX)) {
+        let json = JSON.parse(fs.readFileSync(path.join(DATA_FOLDER, file)));
+        json.url = '/scan-results/data/' + file;
+        if (json.requestedUrl) {
+            for (let key in json.categories) {
+                scores[key] += (json.categories[key].score * 100);
+                totals[key]++;
+            }
+            for (var key in json.audits) {
+                if (json.audits.hasOwnProperty(key)) {
+                    // Accessibility scores are binary. Performance will want a score target.
+                    // Null scores are possible and mean a test wasn't scored, and shouldn't 
+                    // be counted
+                    if (tracking[key] != null && json.audits[key].score == 0) {
+                        tracking[key].count = tracking[key].count + 1;
+                    }
+                    else if (json.audits[key].score == 0) {
+                        // TODO(winerip) record which audit type this test is from.
+                        tracking[key] = {
+                            "count": 1,
+                            "title": json.audits[key].title,
+                            "manual": json.audits[key].score == null,
+                            "description": json.audits[key].description
+                        }
+                    }
+                }
+            }
+            const normalize = ((x) => x ? Math.ceil(x.score * 100) : null)
+            let filteredJsonEntry = {
+                url: json.url,
+                requestedUrl: json.requestedUrl,
+                categories: {
+                    performance: normalize(json.categories.performance),
+                    accessibility: normalize(json.categories.accessibility),
+                    'best-practices': normalize(json.categories['best-practices']),
+                    seo: normalize(json.categories.seo),
+                    pwa: normalize(json.categories.pwa),
+                }
+            }
+            filteredJsonData.push(filteredJsonEntry);
+        }
     }
-}
+});
+
 let averages = {
     performance: Math.ceil(scores.performance / totals.performance),
     accessibility: Math.ceil(scores.accessibility / totals.accessibility),
@@ -45,49 +77,11 @@ let averages = {
     pwa: Math.ceil(scores.pwa / totals.pwa)
 }
 
-let tracking = {};
-for (var i = 0; i < unfilteredJsonData.length; i++) {
-    for (var key in unfilteredJsonData[i].audits) {
-        if (unfilteredJsonData[i].audits.hasOwnProperty(key)) {
-            // Accessibility scores are binary. Performance will want a score target.
-            // Null scores are possible and mean a test wasn't scored, and shouldn't 
-            // be counted
-            if (tracking[key] != null && unfilteredJsonData[i].audits[key].score == 0) {
-                tracking[key].count = tracking[key].count + 1;
-            }
-            else if (unfilteredJsonData[i].audits[key].score == 0) {
-                tracking[key] = {
-                    "count": 1,
-                    "title": unfilteredJsonData[i].audits[key].title,
-                    "manual": unfilteredJsonData[i].audits[key].score == null,
-                    "description": unfilteredJsonData[i].audits[key].description
-                }
-            }
-        }
-    }
-}
 let arr = Object.keys(tracking).map(function (key) {
     return tracking[key];
 });
 arr.sort(sortByCount);
 
-const normalize = ((x) => x ? Math.ceil(x.score * 100) : null)
-
-let filteredJsonData = []
-unfilteredJsonData.forEach(entry => {
-    let filteredJsonEntry = {
-        url: entry.url,
-        requestedUrl: entry.requestedUrl,
-        categories: {
-            performance: normalize(entry.categories.performance),
-            accessibility: normalize(entry.categories.accessibility),
-            'best-practices': normalize(entry.categories['best-practices']),
-            seo: normalize(entry.categories.seo),
-            pwa: normalize(entry.categories.pwa),
-        }
-    }
-    filteredJsonData.push(filteredJsonEntry);
-});
 // arr holds list of issues
 // averages holds averages
 fs.writeFile(


### PR DESCRIPTION
<!-- 
Add some description
change - [ ]  to - [X] to mark it.
 -->
This has no change on the output, but it will no longer push each file's contents into memory before aggregating data, which caused a heap OOM error when run on the full audit in #134 

<!-- 
#### Additional Notes
-  -->
