### PR TITLE
Fix sorting

### DIFF
--- a/src/components/FileResults.js
+++ b/src/components/FileResults.js
@@ -7,6 +7,20 @@ class FileResults extends React.Component {
         this.state = {}
     }
     componentDidMount() {
+        this.props.setNoOfResults(this.props.data.length);
+    }
+    render() {
+        return (
+            <tbody>{this.props.data ? this.renderData() : <tr><td colSpan="3">No results returned.</td></tr>}</tbody>
+        );
+    }
+    renderResult(value) {
+        return (<td className="result">
+            {value ? Math.ceil(value) : 'n/a'}
+        </td>
+        )
+    }
+    renderData() {
         let id = 1;
         let listItems = this.props.data.map((file) => {
             if (file.categories) {
@@ -23,21 +37,7 @@ class FileResults extends React.Component {
             }
             return null;
         });
-        this.setState({
-            rendered: listItems
-        })
-        this.props.setNoOfResults(id - 1);
-    }
-    render() {
-        return (
-            <tbody>{this.props.data ? this.state.rendered : <tr><td colSpan="3">No results returned.</td></tr>}</tbody>
-        );
-    }
-    renderResult(value) {
-        return (<td className="result">
-            {value ? Math.ceil(value) : 'n/a'}
-        </td>
-        )
+        return listItems;
     }
 }
 

--- a/src/components/FilesList.js
+++ b/src/components/FilesList.js
@@ -71,19 +71,12 @@ class FilesList extends React.Component {
             noOfResults: val
         })
     }
-    // TODO this doesn't seem to work. It used to break the page, I've changed it a little but it still doesn't sort.
     sortNestedItems(value) {
         let isAsc = true;
         if (value === this.state.sorting.sortOn)
             isAsc = !this.state.sorting.sortAsc;
         const nested = value.split(".");
         function compare(a, b) {
-            //console.log("comparing " + a + " and " + b);
-            let res = compareReal(a, b);
-            //console.log(res);
-            return res;
-        }
-        function compareReal(a, b) {
             let x = a;
             let y = b;
             for (let i = 0; i < nested.length; i++) {

--- a/src/components/FilesList.js
+++ b/src/components/FilesList.js
@@ -71,6 +71,7 @@ class FilesList extends React.Component {
             noOfResults: val
         })
     }
+    // value is of the form path.to.json.category
     sortNestedItems(value) {
         let isAsc = true;
         if (value === this.state.sorting.sortOn)
@@ -79,6 +80,7 @@ class FilesList extends React.Component {
         function compare(a, b) {
             let x = a;
             let y = b;
+            // find the correct leaf in the json to compare
             for (let i = 0; i < nested.length; i++) {
                 x = x[nested[i]];
                 y = y[nested[i]];
@@ -89,34 +91,8 @@ class FilesList extends React.Component {
             if (typeof y === "string") {
                 y = y.toLowerCase();
             }
-            if (isAsc) {
-                if (x === null) {
-                    return 1;
-                }
-                else if (y === null) {
-                    return -1;
-                }
-                else if (x === y) {
-                    return 0;
-                }
-                else {
-                    return x < y ? -1 : 1;
-                }
-            }
-            else {
-                if (x === null) {
-                    return -1;
-                }
-                else if (y === null) {
-                    return 1;
-                }
-                else if (x === y) {
-                    return 0;
-                }
-                else {
-                    return x > y ? -1 : 1;
-                }
-            }
+            console.log("testing")
+            return (x < y ? -1 : x > y ? 1 : 0) * (isAsc ? 1 : -1)
         }
         this.setState({
             items: this.state.data.sort(compare),

--- a/src/components/FilesList.js
+++ b/src/components/FilesList.js
@@ -78,11 +78,17 @@ class FilesList extends React.Component {
             isAsc = !this.state.sorting.sortAsc;
         const nested = value.split(".");
         function compare(a, b) {
+            //console.log("comparing " + a + " and " + b);
+            let res = compareReal(a, b);
+            //console.log(res);
+            return res;
+        }
+        function compareReal(a, b) {
             let x = a;
             let y = b;
             for (let i = 0; i < nested.length; i++) {
-                x = a[nested[i]];
-                y = b[nested[i]];
+                x = x[nested[i]];
+                y = y[nested[i]];
             }
             if (typeof x === "string") {
                 x = x.toLowerCase();
@@ -146,11 +152,11 @@ class FilesList extends React.Component {
                             <thead>
                                 <tr className="result-item heading">
                                     <SortableHeaderCell title="URL" category="requestedUrl" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
-                                    <SortableHeaderCell title="Performance" category="categories.performance.score" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
-                                    <SortableHeaderCell title="Accessibility" category="categories.accessibility.score" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
-                                    <SortableHeaderCell title="Best Practices" category="categories.best-practices.score" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
-                                    <SortableHeaderCell title="SEO" category="categories.seo.score" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
-                                    <SortableHeaderCell title="Progressive Web App" category="categories.pwa.score" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
+                                    <SortableHeaderCell title="Performance" category="categories.performance" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
+                                    <SortableHeaderCell title="Accessibility" category="categories.accessibility" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
+                                    <SortableHeaderCell title="Best Practices" category="categories.best-practices" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
+                                    <SortableHeaderCell title="SEO" category="categories.seo" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
+                                    <SortableHeaderCell title="Progressive Web App" category="categories.pwa" sorting={this.state.sorting} sortNestedItems={this.sortNestedItems} />
                                 </tr>
                             </thead>
                             <FileResults data={this.state.data} setNoOfResults={this.setNoOfResults} />


### PR DESCRIPTION
<!-- 
Add some description
change - [ ]  to - [X] to mark it.
 -->
Category titles changed with my update, and before that, rendered state of the results was being stored, so when the data was sorted, that section wasn't re-rendered.

The old data also caused problems when trying to sort non-chromeDev JSON results, which caused the exceptions.

Note that sorting for 10,000 URLs does take a non-trivial amount of time. This is probably why state was stored. Memoizing might be a good follow-up to this, I think react has support for that (I saw a reference to useMemo when looking at documentation for sorting). Might be a quick and easy change for someone who knows how to do that in react.
<!-- 
#### Additional Notes
-  -->
