### PR TITLE
Feature/track common elements across pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "last 1 safari version"
     ]
   },
-  "homepage": "https://annahinnyc.github.io/code4good-accessibility",
+  "homepage": "https://winerip.github.io/code4good-accessibility",
   "devDependencies": {
     "exceljs": "^3.8.2",
     "lighthouse": "^5.6.0"

--- a/src/components/CommonElements.js
+++ b/src/components/CommonElements.js
@@ -3,7 +3,7 @@ import DescriptionPopover from './DescriptionPopover.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 
-class TopIssues extends React.Component {
+class CommonElements extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -70,4 +70,4 @@ class TopIssues extends React.Component {
     }
 }
 
-export default TopIssues;
+export default CommonElements;

--- a/src/components/CommonElements.js
+++ b/src/components/CommonElements.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import DescriptionPopover from './DescriptionPopover.js';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+
+class TopIssues extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            data: [],
+            filteredData: [],
+            showMore: false,
+        }
+        this.handleClick = this.handleClick.bind(this);
+    };
+
+    componentDidMount() {
+        let arr = this.props.data;
+        this.setState({
+            data: arr,
+            filteredData: arr.map(item => {
+                item.count.value = item.count.rcb.misc + item.count.rcb.top + item.count.rco.misc + item.count.rco.top;
+                return item;
+            })
+        });
+    }
+
+    handleClick() {
+        if (!this.state.showMore) {
+            this.setState({
+                showMore: true
+            })
+        }
+    }
+
+    render() {
+        let id = 0;
+        let rendered = this.state.filteredData.map(item => {
+            return <tr key={"issue-item-" + id++}>
+                <td className="pointer">
+                    <DescriptionPopover title={item.selector} description={item.domPath} />
+                </td>
+                <td>{item.label}</td>
+                <td><a href={item.exampleUrl} target="_blank" rel="noopener noreferrer"> {item.count.value}</a></td>
+                <td>{item.auditTriggered}</td>
+            </tr>
+        })
+        return (
+            <div>
+                <div className="section-heading"><FontAwesomeIcon icon={faExclamationTriangle} size="lg" /><h2>Common Problematic Nodes</h2></div>
+                <div className={this.state.showMore ? "section" : "section shortened"} onClick={this.handleClick}>
+                    <div className="table-container">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>selector</th>
+                                    <th>label</th>
+                                    <th># of Pages Affected</th>
+                                    <th>Failed Audit</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rendered}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default TopIssues;

--- a/src/components/FilesList.js
+++ b/src/components/FilesList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import '../scss/results.scss';
+import CommonElements from './CommonElements.js';
 import FileResults from './FileResults.js';
 import TopIssues from './TopIssues.js';
 import FileAverages from './FileAverages';
@@ -12,6 +13,7 @@ class FilesList extends React.Component {
         super(props);
         this.state = {
             data: [],
+            nodes: [],
             issues: [],
             averageData: {},
             averages: {
@@ -35,9 +37,14 @@ class FilesList extends React.Component {
 
     componentDidMount() {
         fetch(this.state.url + "issues.json")
-            .then(response => response.json())                      
+            .then(response => response.json())
             .then(json => {
                 this.setState({ issues: json });
+            });
+        fetch(this.state.url + "nodes.json")
+            .then(response => response.json())
+            .then(json => {
+                this.setState({ nodes: json });
             });
         fetch(this.state.url + "averages.json")
             .then(response => response.json())
@@ -129,6 +136,7 @@ class FilesList extends React.Component {
                 {this.state.fetchComplete && <div>
                     <FileAverages averages={this.state.averages} />
                     <TopIssues data={this.state.issues} />
+                    <CommonElements data={this.state.nodes} />
                     <div className="section-heading">
                         <FontAwesomeIcon icon={faList} size="lg" /><h2>All Data</h2>
                     </div>


### PR DESCRIPTION
This reads the list of failing nodes for each accessibility audit, and has the preprocessing script index them by selector and html snippet, then outputs all useful information about these elements in JSON provided they appear on more than one URL, as well as providing a single URL they appear on.

The UI is very minimal, modeled after the Top Issues section, and tries to provide as much of the information as possible in as limited a space as possible. I ran into issues with the snippet, as it contains un-escaped HTML. I guess I should have preprocessing wrap this in single quotes?

This is largely a first pass proof of concept for adding this information to the dashboard. I'm much more comfortable with data processing than the UI stuff, so I'm hoping someone with more experience could take my rough approach here and make it better.

I've based this PR on #139 as I wanted a fully featured version of the dashboard, and that PR should be ready to merge soon.

Demo at https://winerip.github.io/code4good-accessibility